### PR TITLE
Remove Fields list from Update-ProjectItemsBetweenProjects

### DIFF
--- a/Test/private/mocks/invoke-GitHubOrgProjectWithFields-octodemo-626.syncprj.json
+++ b/Test/private/mocks/invoke-GitHubOrgProjectWithFields-octodemo-626.syncprj.json
@@ -123,7 +123,7 @@
                   },
                   {
                     "__typename": "ProjectV2ItemFieldTextValue",
-                    "text": "Issue2",
+                    "text": "Issue3",
                     "field": {
                       "__typename": "ProjectV2Field",
                       "id": "PVTF_lADOAlIw4c4A0QAozgp6Zxc",

--- a/Test/public/integrations/sync-ProjectItemsBetweenProjects.test.ps1
+++ b/Test/public/integrations/sync-ProjectItemsBetweenProjects.test.ps1
@@ -56,14 +56,11 @@ function Test_SyncProjectItemsBetweenProjects_SameValues{
         MockCall_GitHubOrgProjectWithFields -Owner $owner -ProjectNumber $projectNumber -FileName "invoke-GitHubOrgProjectWithFields-$owner-$projectNumber.syncprj.json"
     }
 
-    $fieldlist = @("Int1", "Int2")
-
     $params = @{
         SourceOwner = $owner
         SourceProjectNumber = $sourceProjectNumber
         DestinationOwner = $owner
         DestinationProjectNumber = $destinationProjectNumber
-        FieldsList = $fieldlist
     }
     $result = Update-ProjectItemsBetweenProjects @params
     Assert-IsNull -Object $result

--- a/Test/public/integrations/sync-ProjectItemsBetweenProjects.test.ps1
+++ b/Test/public/integrations/sync-ProjectItemsBetweenProjects.test.ps1
@@ -19,7 +19,6 @@ function Test_SyncProjectItemsBetweenProjects{
         SourceProjectNumber = $sourceProjectNumber
         DestinationOwner = $owner
         DestinationProjectNumber = $destinationProjectNumber
-        FieldsList = $fieldlist
     }
     $result = Update-ProjectItemsBetweenProjects @params
 

--- a/public/integrations/sync-ProjectItemsBetweenProjects.ps1
+++ b/public/integrations/sync-ProjectItemsBetweenProjects.ps1
@@ -31,7 +31,6 @@ function Update-ProjectItemsBetweenProjects {
         [Parameter(Position = 1)][string]$SourceProjectNumber,
         [Parameter(Position = 2)][string]$DestinationOwner,
         [Parameter(Position = 3)][string]$DestinationProjectNumber,
-        [Parameter(Mandatory)][object]$FieldsList,
         [Parameter()][string]$FieldSlug
     )
 
@@ -51,14 +50,8 @@ function Update-ProjectItemsBetweenProjects {
         return $null
     }
 
-    # Check if all fields in fieldlist exist in the source project
-    $sourceFields = $sourceProject.fields.Values
-    $sourceFieldNames = $sourceFields | Select-Object -ExpandProperty name
-    $missingFields = $FieldsList | Where-Object { $_ -notin $sourceFieldNames }
-    if($missingFields.Count -gt 0){
-        "The following fields are missing in the source project: $($missingFields -join ', ')" | Write-MyError
-        return $null
-    }
+    # Check all the fields on the source project
+    $FieldsList = $sourceProject.fields.Values.name
 
     # Get source project items
     $sourceItems = $sourceProject.items.Values


### PR DESCRIPTION
Improve field handling in the `Update-ProjectItemsBetweenProjects` function by removing unnecessary parameters and streamlining the validation process for source project fields.