### PR TITLE
Refactor NotDone parameter to IncludeNotDone for clarity

### DIFF
--- a/Test/public/integrations/select-ProjectItemsDone.test.ps1
+++ b/Test/public/integrations/select-ProjectItemsDone.test.ps1
@@ -9,14 +9,14 @@ function Test_SelectProjectItemNotDone{
     MockCall_GitHubOrgProjectWithFields -Owner $owner -ProjectNumber $projectNumber -FileName 'projectV2.json'
 
     $prj = Get-Project -Owner $Owner -ProjectNumber $ProjectNumber
-    $NotDoneItems = $prj.items.values | Where-Object { $_.Status -ne "Done" }
+    $IncludeNotDoneItems = $prj.items.values | Where-Object { $_.Status -ne "Done" }
     Assert-Count -Expected 12 -Presented $prj.items.values
-    Assert-Count -Expected 9 -Presented $NotDoneItems
+    Assert-Count -Expected 9 -Presented $IncludeNotDoneItems
 
     # Act
     $result = $prj.items | Select-ProjectItemsNotDone
 
-    $NotDoneItems.id | ForEach-Object {
+    $IncludeNotDoneItems.id | ForEach-Object {
         Assert-Contains -Expected $_ -Presented $result.Keys
     }
 }

--- a/Test/public/integrations/update-ProjectItemsStatusOnDueDate.test.ps1
+++ b/Test/public/integrations/update-ProjectItemsStatusOnDueDate.test.ps1
@@ -40,26 +40,26 @@ function Test_UpdateProjectItemStatusOnDueDate{
 
     $staged = Get-ProjectItemStaged -Owner octodemo -ProjectNumber 625
 
-    Assert-Count -Expected 6 -Presented $staged
+    Assert-Count -Expected 5 -Presented $staged
 
     Assert-Contains -Expected PVTI_lADOAlIw4c4A0Lf4zgYNTc0 -Presented $staged.Keys
     Assert-Contains -Expected PVTI_lADOAlIw4c4A0Lf4zgYNTwo -Presented $staged.Keys
     Assert-Contains -Expected PVTI_lADOAlIw4c4A0Lf4zgYNTxI -Presented $staged.Keys
     Assert-Contains -Expected PVTI_lADOAlIw4c4A0Lf4zgYQpRc -Presented $staged.Keys
     Assert-Contains -Expected PVTI_lADOAlIw4c4A0Lf4zgYUeW4 -Presented $staged.Keys
-    Assert-Contains -Expected PVTI_lADOAlIw4c4A0Lf4zgYVsJc -Presented $staged.Keys -Comment "Done item is staged"
-    Assert-NotContains -Expected PVTI_lADOAlIw4c4A0Lf4zgYQpP4 -Presented $staged.Keys -Comment "Item without NCC should not be staged"
+    Assert-NotContains -Expected PVTI_lADOAlIw4c4A0Lf4zgYVsJc -Presented $staged.Keys -Comment "Done item"
+    Assert-NotContains -Expected PVTI_lADOAlIw4c4A0Lf4zgYQpP4 -Presented $staged.Keys -Comment "Item without NCC"
 
     # Act with NotDone
     Reset-ProjectItemStaged -Owner octodemo -ProjectNumber 625
 
     # Act
-    $result = Update-ProjectItemsStatusOnDueDate @params -NotDone
+    $result = Update-ProjectItemsStatusOnDueDate @params -IncludeNotDone
     
     # Assert
     Assert-IsNull -Object $result
     $staged = Get-ProjectItemStaged -Owner octodemo -ProjectNumber 625
-    Assert-Count -Expected 5 -Presented $staged
-    Assert-NotContains -Expected PVTI_lADOAlIw4c4A0Lf4zgYVsJc -Presented $staged.Keys -Comment "Done item should not be staged"
+    Assert-Count -Expected 6 -Presented $staged
+    Assert-Contains -Expected PVTI_lADOAlIw4c4A0Lf4zgYVsJc -Presented $staged.Keys -Comment "Done item "
 
 }

--- a/public/integrations/sync-ProjectItemsBetweenProjects.ps1
+++ b/public/integrations/sync-ProjectItemsBetweenProjects.ps1
@@ -32,7 +32,7 @@ function Update-ProjectItemsBetweenProjects {
         [Parameter(Position = 2)][string]$DestinationOwner,
         [Parameter(Position = 3)][string]$DestinationProjectNumber,
         [Parameter()][string]$FieldSlug,
-        [Parameter()][switch]$NotDone
+        [Parameter()][switch]$IncludeNotDone
     )
 
     # Get destination project for error handling and caching
@@ -56,13 +56,13 @@ function Update-ProjectItemsBetweenProjects {
 
     # Get source project items
     # Filter items based on the NotDone parameter
-    $sourceItems = $NotDone ? $($sourceProject.items | Select-ProjectItemsNotDone) : $sourceProject.items
+    $sourceItems = $IncludeNotDone ? $sourceProject.items : $($sourceProject.items | Select-ProjectItemsNotDone)
 
     # Process each item in the source project
     foreach($sourceItem in $sourceItems.Values){
-        # Find matchin item destination project
+        # Find matching item in destination project
         # Use URL
-        # By the moment we are not going to sync Drafts as they belong to single project and therefore no matching is posible
+        # By the moment we are not going to sync Drafts as they belong to single project and therefore no matching is possible
         if($null -eq $sourceItem.url){
             "Item with no URL probably a draft. Skipping." | Write-MyVerbose
             continue

--- a/public/integrations/update-ProjectItemsStatusOnDueDate.ps1
+++ b/public/integrations/update-ProjectItemsStatusOnDueDate.ps1
@@ -27,7 +27,7 @@ function Update-ProjectItemsStatusOnDueDate{
         [Parameter(Position = 2)][string]$DueDateFieldName,
         [Parameter(Position = 3)][string]$Status,
         [Parameter()][switch]$Force,
-        [Parameter()][switch]$NotDone
+        [Parameter()][switch]$IncludeNotDone
     )
 
     "Updating project items status with due date for project $owner/$ProjectNumber" | Write-MyHost
@@ -44,7 +44,7 @@ function Update-ProjectItemsStatusOnDueDate{
     $prj = Get-Project -Owner $Owner -ProjectNumber $ProjectNumber -Force:$Force
 
     # Filter items based on the NotDone parameter
-    $items = $NotDone ? $($prj.items | Select-ProjectItemsNotDone) : $prj.items
+    $items = $IncludeNotDone ? $prj.items : $($prj.items | Select-ProjectItemsNotDone)
 
     $itemKeys = $items.Keys
 

--- a/public/integrations/update-ProjectItemsWithIntegration.ps1
+++ b/public/integrations/update-ProjectItemsWithIntegration.ps1
@@ -19,7 +19,7 @@ function Update-ProjectItemsWithIntegration{
         [Parameter(Mandatory)][string]$IntegrationField,
         [Parameter(Mandatory)][string]$IntegrationCommand,
         [Parameter()] [string]$Slug,
-        [Parameter()] [switch]$NotDone
+        [Parameter()] [switch]$IncludeNotDone
     )
     ($Owner,$ProjectNumber) = Get-OwnerAndProjectNumber -Owner $Owner -ProjectNumber $ProjectNumber
     if([string]::IsNullOrWhiteSpace($owner) -or [string]::IsNullOrWhiteSpace($ProjectNumber)){ "Owner and ProjectNumber are required" | Write-MyError; return $null}
@@ -33,7 +33,7 @@ function Update-ProjectItemsWithIntegration{
     $project = Get-Project -Owner $owner -ProjectNumber $projectNumber -Force
 
     # Filter items based on the NotDone parameter
-    $items = $NotDone ? $($project.items | Select-ProjectItemsNotDone) : $project.items
+    $items = $IncludeNotDone ? $project.items : $($project.items | Select-ProjectItemsNotDone)
 
     # Extract all items that have value on the integration field.
     # This field is the value that will work as parameter to the integration command


### PR DESCRIPTION
Rename the NotDone parameter to IncludeNotDone across multiple functions to enhance clarity and improve logic handling. Adjust related assertions and filtering to align with the new parameter name.