### PR TITLE
feat(prompt): implement project helper prompt functions

### DIFF
--- a/Test/private/mockdatabase.ps1
+++ b/Test/private/mockdatabase.ps1
@@ -1,6 +1,14 @@
 function Mock_DatabaseRoot([switch]$NotReset){
 
-    MockCallToString "Invoke-ProjectHelperGetDatabaseStorePath" -OutString "test_database_path"
+    $folderName = "test_database_path"
+    # Check if the database path exists
+    if (-Not (Test-Path -Path $folderName -PathType Container)) {
+        New-Item -Path $folderName -ItemType Directory -Force | Out-Null
+    }
+
+    $fullpath = $folderName | Convert-path
+    
+    MockCallToString "Invoke-ProjectHelperGetDatabaseStorePath" -OutString $fullpath
 
     #check $NotReset
     if(-Not $NotReset){

--- a/Test/public/getPrompt.test.ps1
+++ b/Test/public/getPrompt.test.ps1
@@ -1,0 +1,24 @@
+function Test_GetProjecthelperPrompt{
+
+    Mock_DatabaseRoot
+
+    # No environment return null
+    $result = Get-ProjecthelperPrompt
+    Assert-StringIsNullOrEmpty $result
+
+    # No environment with new line return null
+    $result = Get-ProjecthelperPrompt -WithNewLine
+    Assert-StringIsNullOrEmpty $result
+
+    # Set environment with empty values
+    Set-ProjectHelperEnvironment -Owner "TestOwner" -ProjectNumber "12345" -DisplayFields @("Field1", "Field2")
+
+    # With environment return "[TestOwner/12345/0]"
+    $result = Get-ProjecthelperPrompt
+    Assert-AreEqual $result "[TestOwner/12345/0]"
+
+    # With environment and new line return "[TestOwner/12345/0]`n"
+    $result = Get-ProjecthelperPrompt -WithNewLine
+    Assert-AreEqual $result "[TestOwner/12345/0]`n"
+
+}

--- a/public/environmentCache.ps1
+++ b/public/environmentCache.ps1
@@ -26,6 +26,20 @@ function Reset-ProjectHelperEnvironment{
 
 } Export-ModuleMember -Function Reset-ProjectHelperEnvironment
 
+function Set-ProjectHelperEnvironment{
+    [CmdletBinding()]
+    param(
+        [Parameter()][string]$Owner,
+        [Parameter()][string]$ProjectNumber,
+        [Parameter()][string[]]$DisplayFields
+    )
+
+    Set-EnvItem -Name "EnvironmentCache_Owner" -Value $owner
+    Set-EnvItem -Name "EnvironmentCache_ProjectNumber" -Value $projectNumber
+    Set-EnvItem -Name "EnvironmentCache_Display_Fields" -Value $displayFields
+
+} Export-ModuleMember -Function Set-ProjectHelperEnvironment
+
 function Get-OwnerAndProjectNumber{
     [CmdletBinding()]
     param(

--- a/public/getPrompt.ps1
+++ b/public/getPrompt.ps1
@@ -1,0 +1,47 @@
+function Get-ProjecthelperPrompt{
+    [CmdletBinding()]
+    param(
+        [switch]$WithNewLine
+    )
+
+    $env = Get-ProjectHelperEnvironment
+
+    $owner = $env.Owner
+    $projectNumber = $env.ProjectNumber
+
+    if(-not $owner -and -not $projectNumber){
+        return [string]::Empty
+    }
+    
+    # Get Staged items
+    $db = Get-ProjectFromDatabase -Owner $Owner -ProjectNumber $ProjectNumber
+    $count = $db.Staged.Values.count
+
+    # Build prompt text
+    $prompt = "[$owner/$projectNumber/$count]"
+
+    if($WithNewLine){
+        $prompt = "$prompt`n"
+    }
+
+    return $prompt
+
+} Export-ModuleMember -Function Get-ProjecthelperPrompt
+
+function Set-ProjecthelperPrompt{
+    [CmdletBinding()]
+    param()
+
+    if($GitPromptSettings){
+        "Setting Prompt with posh-git integration" | Write-Host
+        $GitPromptSettings.DefaultPromptBeforeSuffix.Text ='`n$(Get-ProjecthelperPrompt -WithNewLine)'
+        $GitPromptSettings.DefaultPromptBeforeSuffix.ForegroundColor = 'Red'
+        return
+    }
+
+    # Default prompt setup
+    "Setting Default Prompt" | Write-Host
+    $function:prompt = { "$(Get-ProjecthelperPrompt) $($ExecutionContext.SessionState.Path.CurrentLocation)> " }
+
+} Export-ModuleMember -Function Set-ProjecthelperPrompt
+


### PR DESCRIPTION
Introduce `Get-ProjecthelperPrompt` and `Set-ProjecthelperPrompt` functions for prompt integration. These functions manage the display of project-related information in the command prompt, enhancing user experience by providing context about the current project environment. Additionally, implement `Set-ProjectHelperEnvironment` to set necessary environment variables.