### PR TITLE
fix: correct variable access and remove redundancy in project item handling

### DIFF
--- a/private/item/itemhelper.ps1
+++ b/private/item/itemhelper.ps1
@@ -15,4 +15,4 @@ function Get-RepoOwnerNameNumberFromUrl{
     }
 
     return $owner, $repoName, $number
-} Export-ModuleMember -function Get-RepoOwnerNameNumberFromUrl
+}

--- a/public/getPrompt.ps1
+++ b/public/getPrompt.ps1
@@ -46,7 +46,7 @@ function Get-ProjecthelperPromptSettings {
     }
 
     return $global:ProjecthelperPromoptSettings
-}
+} 
 
 function Write-ProjecthelperPrompt {
     [CmdletBinding()]
@@ -79,7 +79,7 @@ function Write-ProjecthelperPrompt {
 
     # Get Staged items
     $stagedItems = Get-ProjectItemStaged
-    $count = $stagedItems.Values.Values.Count
+    $count = $stagedItems.values.Keys.Count
 
     # Build prompt text
 
@@ -157,7 +157,6 @@ function Set-ProjecthelperPrompt {
             "Previouse prompt git variable not found, created it with value: $($s.PreviousPromptGit)" | Write-Verbose
         }
         else {
-            $s.PreviousPromptGit = $s.PreviousPromptGit
             "Previouse prompt git variable found with value $($s.PreviousPromptGit)" | Write-Verbose
         }
 

--- a/public/project_item.ps1
+++ b/public/project_item.ps1
@@ -115,7 +115,11 @@ function Add-ProjectItem{
 
         if($response.data.addProjectV2ItemById.item.id)
         {
-            return $response.data.addProjectV2ItemById.item.id
+            $ret = $response.data.addProjectV2ItemById.item.id
+            $global:ItemId = $ret
+
+            return $ret
+            
         } else {
             "Item not added to project" | Write-MyError
             return $null


### PR DESCRIPTION
Improve variable access in the `Get-ProjecthelperPromptSettings` and `Add-ProjectItem` functions, while removing unnecessary assignments and redundant statements. Store the item ID in a global variable after adding a project item.