### PR TITLE
fix(integration): correct quotes for key parameter in Update-ProjectItemsWithIntegration call

### DIFF
--- a/Test/public/integrations/update-ProjectItemsWithIntegration.test.ps1
+++ b/Test/public/integrations/update-ProjectItemsWithIntegration.test.ps1
@@ -28,8 +28,8 @@ function Test_UpdateProjectWithIntegration{
         "Number1" = 22
     }
 
-    MockCallToObject -Command "Get-SfAccount https://some.com/1234/viuew" -OutObject $data1
-    MockCallToObject -Command "Get-SfAccount https://some.com/4321/viuew" -OutObject $data2
+    MockCallToObject -Command 'Get-SfAccount "https://some.com/1234/viuew"' -OutObject $data1
+    MockCallToObject -Command 'Get-SfAccount "https://some.com/4321/viuew"' -OutObject $data2
 
     $param = @{
         Owner = $owner

--- a/public/integrations/update-ProjectItemsWithIntegration.ps1
+++ b/public/integrations/update-ProjectItemsWithIntegration.ps1
@@ -67,7 +67,9 @@ function Invoke-ProjectInjectionWithIntegration{
 
         try {
             "Calling integration [ $IntegrationCommand $($item.$IntegrationField)]" | Write-MyHost
-            $values = Invoke-MyCommand -Command "$IntegrationCommand $($item.$IntegrationField)"
+            $command = $IntegrationCommand + " " + '"{key}"'
+            $command = $command -replace '{key}', $item.$IntegrationField
+            $values = Invoke-MyCommand -Command $command
         }
         catch {
             "Something went wrong with the integration command for $($item.id)" | Write-Error


### PR DESCRIPTION
Improves the integration call by ensuring the key parameter is properly quoted. This change enhances the reliability of the command execution.