### PR TITLE
fix(Set-LastComment): correct comment addition logic for single comment case

### DIFF
--- a/private/projectDatabase/project_database_Item.ps1
+++ b/private/projectDatabase/project_database_Item.ps1
@@ -64,9 +64,15 @@ function Set-LastComment{
         $Item.comments = @()
     }
 
+    # Check if it has just one
+    if($Item.comments -is [hashtable]){
+        $Item.comments = @($Item.comments) + $commentobj
+    } else {
+        $Item.comments += ($commentobj)
+    }
+
     # Update commentLast field
     $Item.commentLast = $commentobj
-    $Item.comments += $commentobj
 }
 
 function Find-Item {


### PR DESCRIPTION
Correct the logic for adding comments to handle cases where only a single comment exists. This change ensures that comments are properly added to the item regardless of whether it starts as a hashtable or an array.