### PR TITLE
fix(Sync-ProjectItemStagedAsync): add error when trying to change a field not supported by a Draft

### DIFF
--- a/Test/public/project_items_staged_Async.test.ps1
+++ b/Test/public/project_items_staged_Async.test.ps1
@@ -591,6 +591,39 @@ function Test_SyncProjectItemsStaged_Async_SUCCESS_Content_DraftIssue {
     Assert-AreEqual -Expected $fieldBodyValue1 -Presented $item1.$fieldBody
 }
 
+function Test_SyncProjectItemsStaged_Async_FAIL_Content_DraftIssue {
+
+    # Arrange
+    Reset-InvokeCommandMock
+    Enable-InvokeCommandAliasModule
+
+    $p = Get-Mock_Project_700 ; $owner = $p.owner ; $projectNumber = $p.number
+    MockCall_GetProject -MockProject $p -skipItems
+
+    $i = $p.draftIssue
+    $id = $i.id
+    $fieldName = "AddComment"
+    $fieldAddCommentValue = "new comment added"
+
+    MockCall_GetItem -ItemId $id
+
+    # Edit fields - stage an AddComment edit for a DraftIssue
+    Edit-ProjectItem -Owner $owner -ProjectNumber $projectNumber $id $fieldName $fieldAddCommentValue
+
+    # Act - Sync should throw because DraftIssue does not support AddComment
+    $hasThrown = $false
+    try {
+        Sync-ProjectItemStagedAsync -Owner $owner -ProjectNumber $projectNumber
+    } catch {
+        $hasThrown = $true
+        Assert-AreEqual -Expected "FieldId addcomment not supported for DraftIssue update" -Presented $_.Exception.Message
+    }
+
+    # Assert
+    Assert-IsTrue -Condition $hasThrown
+}
+
+
 function Test_SyncProjectItemsStaged_Async_debug {
 
     Assert-SkipTest

--- a/private/projectDatabase/project_database_call.ps1
+++ b/private/projectDatabase/project_database_call.ps1
@@ -276,8 +276,17 @@ function Update-DraftIssue {
 
     $params = @{
         id    = $Id
-        title = if ($FieldId -eq "title") { $Value } else { "" }
-        body  = if ($FieldId -eq "body") { $Value } else { "" }
+        title = ""
+        body  = ""
+    }
+
+    switch ($FieldId) {
+        "title" { $params.title = $Value ; Break }
+        "body"  { $params.body  = $Value ; Break }
+
+        Default {
+            throw "FieldId $FieldId not supported for DraftIssue update"
+        }
     }
 
     if ($Async) {


### PR DESCRIPTION
Introduce a test to validate the handling of DraftIssue updates in the Sync-ProjectItemStagedAsync function, ensuring that unsupported fields trigger the appropriate exceptions.