### PR TITLE
Several improvements

### DIFF
--- a/private/projectDatabase/project_database.ps1
+++ b/private/projectDatabase/project_database.ps1
@@ -231,7 +231,7 @@ function resetProjectDatabaseCache{
 
     "Resetting project cache for $KeyLock" | Write-MyDebug -Section "ProjectDatabase"
 
-    Reset.Database -Key $KeyLock
+    Reset-Database -Key $KeyLock
     
     $script:ProjectDatabaseCache.Remove($KeyLock)
 }

--- a/private/projectDatabase/project_database.ps1
+++ b/private/projectDatabase/project_database.ps1
@@ -50,8 +50,10 @@ function Get-ProjectFromDatabase{
     $prj = getProjectDatabaseCache -KeyLock $keyLock
 
     if($null -ne $prj){
-        "Project cache hit for $Owner/$ProjectNumber" | Write-MyDebug -Section "ProjectDatabase"
+        "🟩 Get Project from MEMORY $Owner/$ProjectNumber" | Write-MyDebug -Section "ProjectDatabase"
         return $prj
+    } else {
+        "🟧 Get Project from DATABASE $Owner/$ProjectNumber" | Write-MyDebug -Section "ProjectDatabase"
     }
     
     # No cache or cache mismatch, read from database
@@ -64,6 +66,8 @@ function Get-ProjectFromDatabase{
     $prj.fields = $prj.fields | Copy-MyHashTable
     $prj.items  = $prj.items  | Copy-MyHashTable
     $prj.Staged = $prj.Staged | Copy-MyHashTable
+
+    setProjectDatabaseCache -KeyLock $keyLock -SafeId $prj.safeId -Database $prj
 
     return $prj
 }
@@ -161,6 +165,8 @@ function Save-ProjectDatabase{
     # Add safe mark
     $Database.safeId = [guid]::NewGuid().ToString()
 
+    "🟥 Set Project from DATABASE $Owner/$ProjectNumber safeid [$($Database.safeId)]" | Write-MyDebug -Section "ProjectDatabase"
+
     # Save database
     Save-Database -Key $dbkey -Database $Database
     setProjectDatabaseCache -KeyLock $dbkeyLock -SafeId $Database.safeId -Database $Database
@@ -177,61 +183,4 @@ function Get-ProjectDatabaseKey{
     $keylock = "$key-lock"
 
     return $key, $keylock
-}
-
-$script:ProjectDatabaseCache = @{}
-
-function getProjectDatabaseCache{
-    param(
-        [Parameter(Mandatory,Position = 0)][string]$KeyLock
-    )
-
-    $lock = Get-Database -Key $KeyLock
-
-    if([string]::IsNullOrWhiteSpace($lock)){
-        "No cache lock found for $KeyLock. Cache will be ignored." | Write-MyDebug -Section "ProjectDatabase"
-        return $null
-    }
-
-    $cache = $script:ProjectDatabaseCache[$KeyLock]
-
-    if($lock -cne $cache.safeId) {
-        "Cache lock mismatch for $KeyLock. Cache safeId [$($cache.SafeId)], lock [$lock]. Cache will be ignored." | Write-MyDebug -Section "ProjectDatabase"
-        resetProjectDatabaseCache -KeyLock $KeyLock
-        return $null
-    }
-
-    "Getting fields cache for $KeyLock with lock [$lock] and cache safeId [$($cache.SafeId)]" | Write-MyDebug -Section "ProjectDatabase"
-    return $cache.Database
-}
-
-function setProjectDatabaseCache{
-    param(
-        [Parameter(Mandatory,Position = 0)][string]$KeyLock,
-        [Parameter(Mandatory,Position = 1)][string]$SafeId,
-        [Parameter(Mandatory,Position = 2)][object]$Database
-    )
-
-    "Setting project cache for $KeyLock with safeId [$SafeId]" | Write-MyDebug -Section "ProjectDatabase"
-
-    # Save safeId to project-lock
-    Save-Database -Database $SafeId -Key $KeyLock
-
-     # Set lock in database to prevent concurrent updates
-    $script:ProjectDatabaseCache[$KeyLock] = @{
-        Database = $Database
-        SafeId = $SafeId
-    }
-}
-
-function resetProjectDatabaseCache{
-    param(
-        [Parameter(Mandatory,Position = 0)][string]$KeyLock
-    )
-
-    "Resetting project cache for $KeyLock" | Write-MyDebug -Section "ProjectDatabase"
-
-    Reset-Database -Key $KeyLock
-    
-    $script:ProjectDatabaseCache.Remove($KeyLock)
 }

--- a/private/projectDatabase/project_database_cache.ps1
+++ b/private/projectDatabase/project_database_cache.ps1
@@ -1,0 +1,56 @@
+$script:ProjectDatabaseCache = @{}
+
+function getProjectDatabaseCache{
+    param(
+        [Parameter(Mandatory,Position = 0)][string]$KeyLock
+    )
+
+    $lock = Get-Database -Key $KeyLock
+
+    if([string]::IsNullOrWhiteSpace($lock)){
+        "No cache lock found for $KeyLock. Cache will be ignored." | Write-MyDebug -Section "ProjectDatabaseCache"
+        return $null
+    }
+
+    $cache = $script:ProjectDatabaseCache[$KeyLock]
+
+    if($lock -cne $cache.safeId) {
+        "Cache lock mismatch for $KeyLock. Cache safeId [$($cache.SafeId)], lock [$lock]. Cache will be ignored." | Write-MyDebug -Section "ProjectDatabaseCache"
+        resetProjectDatabaseCache -KeyLock $KeyLock
+        return $null
+    }
+
+    "Getting fields cache for $KeyLock with lock [$lock] and cache safeId [$($cache.SafeId)]" | Write-MyDebug -Section "ProjectDatabaseCache"
+    return $cache.Database
+}
+
+function setProjectDatabaseCache{
+    param(
+        [Parameter(Mandatory,Position = 0)][string]$KeyLock,
+        [Parameter(Mandatory,Position = 1)][string]$SafeId,
+        [Parameter(Mandatory,Position = 2)][object]$Database
+    )
+
+    "Setting project cache for $KeyLock with safeId [$SafeId]" | Write-MyDebug -Section "ProjectDatabaseCache"
+
+    # Save safeId to project-lock
+    Save-Database -Database $SafeId -Key $KeyLock
+
+     # Set lock in database to prevent concurrent updates
+    $script:ProjectDatabaseCache[$KeyLock] = @{
+        Database = $Database
+        SafeId = $SafeId
+    }
+}
+
+function resetProjectDatabaseCache{
+    param(
+        [Parameter(Mandatory,Position = 0)][string]$KeyLock
+    )
+
+    "Resetting project cache for $KeyLock" | Write-MyDebug -Section "ProjectDatabase"
+
+    Reset-Database -Key $KeyLock
+    
+    $script:ProjectDatabaseCache.Remove($KeyLock)
+}

--- a/public/fields/getValidNames.ps1
+++ b/public/fields/getValidNames.ps1
@@ -14,10 +14,11 @@ function Get-ValidNames{
         return $null
     }
 
-    $field = Get-ProjectFields -Owner $owner -ProjectNumber $projectNumber -Name $FieldName
+    $field = Get-ProjectFields -Owner $owner -ProjectNumber $projectNumber -Name $FieldName -Exact
 
     if($field.dataType -eq "SINGLE_SELECT"){
         $ret = $field.MoreInfo
+        $ret +=""
     } else {
         throw "Get-ValidNames only supports fields with SINGLE_SELECT dataType. Field $FieldName has $($field.dataType) dataType."
     }

--- a/public/fields/project_fields_list.ps1
+++ b/public/fields/project_fields_list.ps1
@@ -38,6 +38,7 @@ function Get-ProjectFields{
         [Parameter()] [string]$Owner,
         [Parameter()] [string]$ProjectNumber,
         [Parameter(Position = 0)][string]$Name,
+        [Parameter()][switch]$Exact,
         [Parameter()][switch]$Force
     )
 
@@ -61,7 +62,11 @@ function Get-ProjectFields{
     # if name
     if($Name){
         # Filter fields by name
-        $fieldList = $fieldList | Where-Object { $_.name -like "*$Name*" }
+        if($Exact){
+            $fieldList = $fieldList | Where-Object { $_.name -eq $Name }
+        } else {
+            $fieldList = $fieldList | Where-Object { $_.name -like "*$Name*" }
+        }
     }
 
     # return if #db is null

--- a/public/items/edit_project_item.ps1
+++ b/public/items/edit_project_item.ps1
@@ -82,7 +82,7 @@ function Edit-ProjectItem {
 
         # Default
         if($DefaultValues){
-            Write-MyWarning "No Default values are currently setup. Please use other parameters to set values or update the DefaultValues parameter with default values"
+            "DefaultValues EMPTY" | Write-MyDebug -section "Edit-ProjectItem"
 
             # Do not edit but leave this parameters flow the edit process
         }

--- a/public/items/use_order.ps1
+++ b/public/items/use_order.ps1
@@ -57,7 +57,7 @@ function Use-Order {
         #return item
         if($PassThru) {
             $i = Get-ProjectItem -ItemId $itemId
-            return [PsCustomObject]$i
+            Write-Output ([PsCustomObject]$i)
         }
 
         # Get function to show item
@@ -71,7 +71,6 @@ function Use-Order {
             ClearScreen = $ClearScreen
         }
         $ShowProjectItemScriptBlock.Invoke($params)
-        return
 
     }
 } Export-ModuleMember -Function Use-Order -Alias "uo"

--- a/public/items/use_order.ps1
+++ b/public/items/use_order.ps1
@@ -74,18 +74,5 @@ function Use-Order {
             $i = Get-ProjectItem -ItemId $itemId
             Write-Output ([PsCustomObject]$i)
         }
-
-        # Get function to show item
-        $ShowProjectItemScriptBlock = $ShowProjectItemScriptBlock ?? { param($parameters) Show-ProjectItem @parameters }
-
-        # Show item in console or editor
-        $params = @{
-            Item = $itemId
-            OpenInEditor = $OpenInEditor
-            OpenInBrowser = $OpenInBrowser
-            ClearScreen = $ClearScreen
-        }
-        $ShowProjectItemScriptBlock.Invoke($params)
-
     }
 } Export-ModuleMember -Function Use-Order -Alias "uo"


### PR DESCRIPTION
Replace the warning message with debug output for empty DefaultValues and ensure consistency by changing the return statement to Write-Output. Introduce an Exact parameter for precise field name filtering and allow empty parameters as valid values.

- fix(Edit-ProjectItem): replace warning message with debug output for empty DefaultValues

- fix(Use-Order): change return statement to Write-Output for consistency

- feat(Get-ProjectFields): add Exact parameter for precise field name filtering

- fit(Get-ValidNames): add "" as valid value to allow empty parameters